### PR TITLE
Implement change root flag

### DIFF
--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -637,5 +637,40 @@ listY: [ Yo, Yo, Yo ]
 				}
 			})
 		})
+
+		Context("change root for comparison", func() {
+			It("should change the root of an input file", func() {
+				from := InputFile{Location: "/ginkgo/compare/test/from", Documents: loadTestDocuments(`---
+a: foo
+---
+b: bar
+`)}
+
+				to := InputFile{Location: "/ginkgo/compare/test/to", Documents: loadTestDocuments(`{
+"items": [
+  {"a": "Foo"},
+  {"b": "Bar"}
+]
+}`)}
+
+				err := ChangeRoot(&to, "/items", true)
+				if err != nil {
+					Fail(err.Error())
+				}
+
+				results, err := CompareInputFiles(from, to)
+				Expect(err).To(BeNil())
+
+				expected := []Diff{
+					singleDiff("#0/a", MODIFICATION, "foo", "Foo"),
+					singleDiff("#1/b", MODIFICATION, "bar", "Bar"),
+				}
+
+				Expect(len(results.Diffs)).To(BeEquivalentTo(len(expected)))
+				for i, result := range results.Diffs {
+					Expect(result).To(BeEquivalentTo(expected[i]))
+				}
+			})
+		})
 	})
 })

--- a/pkg/dyff/core_suite_test.go
+++ b/pkg/dyff/core_suite_test.go
@@ -204,3 +204,35 @@ func compare(from interface{}, to interface{}) ([]Diff, error) {
 
 	return report.Diffs, nil
 }
+
+func loadTestDocuments(input string) []interface{} {
+	documents, err := LoadDocuments([]byte(input))
+	if err != nil {
+		Fail(err.Error())
+	}
+
+	return documents
+}
+
+func grab(obj interface{}, path string) interface{} {
+	value, err := Grab(obj, path)
+	if err != nil {
+		out, _ := ToYAMLString(obj)
+		Fail(fmt.Sprintf("Failed to grab by path %s from %s", path, out))
+	}
+
+	return value
+}
+
+func grabError(obj interface{}, path string) string {
+	value, err := Grab(obj, path)
+	Expect(value).To(BeNil())
+	return err.Error()
+}
+
+func pathFromString(path string, obj interface{}) Path {
+	result, err := StringToPath(path, obj)
+	Expect(err).To(BeNil())
+
+	return result
+}

--- a/pkg/dyff/input.go
+++ b/pkg/dyff/input.go
@@ -39,12 +39,14 @@ import (
 // InputFile represents the actual input file (either local, or fetched remotely) that needs to be processed. It can contain multiple documents, where a document is a map or a list of things.
 type InputFile struct {
 	Location  string
+	Note      string
 	Documents []interface{}
 }
 
 // HumanReadableLocationInformation create a nicely decorated information about the provided input location. It will output the absolut path of the file (rather than the possibly relative location), or it will show the URL in the usual look-and-feel of URIs.
 func HumanReadableLocationInformation(inputFile InputFile) string {
 	location := inputFile.Location
+	note := inputFile.Note
 	documents := len(inputFile.Documents)
 
 	var buf bytes.Buffer
@@ -63,9 +65,16 @@ func HumanReadableLocationInformation(inputFile InputFile) string {
 		buf.WriteString(Color(location, color.FgHiBlue, color.Underline))
 	}
 
+	// Add additional note if it is set
+	if note != "" {
+		buf.WriteString(", ")
+		buf.WriteString(Color(note, color.FgCyan))
+	}
+
 	// Add an information about how many documents are in the provided input file
 	if documents > 1 {
-		buf.WriteString(Color(" ("+Plural(documents, "document")+")", color.FgHiCyan))
+		buf.WriteString(", ")
+		buf.WriteString(Color(Plural(documents, "document"), color.FgHiCyan, color.Bold))
 	}
 
 	return buf.String()

--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -50,7 +50,8 @@ const banner = `     _        __  __
         |___/
 `
 
-func pathToString(path Path, showDocumentIdx bool) string {
+// PathToString returns a nicely formatted version of the provided path based on the user-preference for the style
+func PathToString(path Path, showDocumentIdx bool) string {
 	if UseGoPatchPaths {
 		return ToGoPatchStyle(path, showDocumentIdx)
 	}
@@ -89,7 +90,7 @@ func CreateHumanStyleReport(report Report, showBanner bool) string {
 // generateHumanDiffOutput creates a human readable report of the provided diff and writes this into the given bytes buffer. There is an optional flag to indicate whether the document index (which documents of the input file) should be included in the report of the path of the difference.
 func generateHumanDiffOutput(output *bytes.Buffer, diff Diff, showDocumentIdx bool) error {
 	output.WriteString("\n")
-	output.WriteString(pathToString(diff.Path, showDocumentIdx))
+	output.WriteString(PathToString(diff.Path, showDocumentIdx))
 	output.WriteString("\n")
 
 	blocks := make([]string, len(diff.Details))


### PR DESCRIPTION
Add flags and implementation code to support changing the root level
of a given input file, or both. Depending on the actual object that
is referenced by the path that serves as the new root level, there
are use cases where a list should be translated into documents, or
where the list is used as the root level itself.

This should fix #3 